### PR TITLE
Avoid useless snapshot updates

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -278,6 +278,7 @@ func fromSnapshot(name string, comparable snapshots.Comparable, limitOS bool, co
 			if err := fcNew.dump(snapshotFilePath); err != nil {
 				panic(err)
 			}
+			return nil
 		}
 		return &ErrTestErrored{
 			err: fmt.Errorf("comparing expectation to result: %w", err),
@@ -293,6 +294,7 @@ func fromSnapshot(name string, comparable snapshots.Comparable, limitOS bool, co
 			if err := fcNew.dump(snapshotFilePath); err != nil {
 				panic(err)
 			}
+			return nil
 		}
 		return &ErrTestFailed{failure: diff}
 	}

--- a/asserts_test.go
+++ b/asserts_test.go
@@ -82,7 +82,7 @@ func Test_fromSnapshot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := fromSnapshot(tt.args.name, tt.args.comparable, tt.args.limitOS, tt.args.config); (err != nil) != tt.wantErr {
-				t.Errorf("fromSnapshot() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("fromSnapshot(%s) error = %v, wantErr %v", tt.args.name, err, tt.wantErr)
 			}
 		})
 	}

--- a/snapshots/comparabletypes/string.go
+++ b/snapshots/comparabletypes/string.go
@@ -42,6 +42,10 @@ func (s *PrettyStringComparable) CompareTo(c snapshots.Comparable) (string, erro
 
 func (s *StringComparable) compareTo(c snapshots.Comparable, pretty bool) (string, error) {
 	otherStr := c.String()
+	// let's save some time, also i think Diffmatchpatch returns a DiffEqual token if all is equal
+	if s.string == otherStr {
+		return "", nil
+	}
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(s.string, otherStr, false)
 
@@ -55,7 +59,7 @@ func (s *StringComparable) compareTo(c snapshots.Comparable, pretty bool) (strin
 				hasLastNewLine := diff.Text[len(diff.Text)-1] == '\n'
 				lines := strings.Split(diff.Text, "\n")
 				l := len(lines)
-				lower, upper := s.contextSize, l - s.contextSize
+				lower, upper := s.contextSize, l-s.contextSize
 				// if there's no newline at the end, we need to take one more line, since the last one will
 				// immediately be followed by an edit, so it doesn't really count as context
 				if !hasLastNewLine {


### PR DESCRIPTION
We sometimes update when there are no changes in the body. This approach runs the exact same test and updates if there is diff. The patch also adds some resiliency for dumb errors that should not be show stoppers.