### PR TITLE
Horacio/allow per test config

### DIFF
--- a/asserts.go
+++ b/asserts.go
@@ -166,11 +166,24 @@ func FromSnapshot(t *testing.T, name string, comparable snapshots.Comparable) {
 	doCompareAndEvaluateResult(t, name, comparable, false)
 }
 
+// FromSnapshotWithConfig will fail if the stored information is not equal (in a non-agnostic comparison) to the passed
+// comparabletypes, the config will be overriden/updated with the passed one.
+func FromSnapshotWithConfig(t *testing.T, name string, comparable snapshots.Comparable, config *Config) {
+	doCompareAndEvaluateResultWithConfig(t, name, comparable, false, config)
+}
+
 // FromOSDependentSnapshot will fail if the stored information is not equal (in a non-agnostic comparison) to the passed
 // comparabletypes but only if the OS of both matches, this should prevent weird side effect of snapshotting in different
 // machines.
 func FromOSDependentSnapshot(t *testing.T, name string, comparable snapshots.Comparable) {
 	doCompareAndEvaluateResult(t, name, comparable, true)
+}
+
+// FromOSDependentSnapshotWithConfig will fail if the stored information is not equal (in a non-agnostic comparison) to the passed
+// comparabletypes but only if the OS of both matches, this should prevent weird side effect of snapshotting in different
+// machines, the config will be overriden/updated with the passed one
+func FromOSDependentSnapshotWithConfig(t *testing.T, name string, comparable snapshots.Comparable, config *Config) {
+	doCompareAndEvaluateResultWithConfig(t, name, comparable, true, config)
 }
 
 // doCompareAndEvaluateResult does the actual snapshot running and decides if and how to fail according to results.
@@ -179,6 +192,13 @@ func doCompareAndEvaluateResult(t *testing.T, name string, comparable snapshots.
 	if err != nil {
 		t.Fatal(err)
 	}
+	doCompareAndEvaluateResultWithConfig(t, name, comparable, limitOs, config)
+}
+
+// doCompareAndEvaluateResult does the actual snapshot running and decides if and how to fail according to results.
+func doCompareAndEvaluateResultWithConfig(t *testing.T, name string, comparable snapshots.Comparable, limitOs bool,
+	config *Config) {
+
 	if err := fromSnapshot(name, comparable, limitOs, config); err != nil {
 		if errors.Is(err, &ErrTestErrored{}) {
 			t.Fatal(errors.Unwrap(err))

--- a/examples/string_difference_test.go
+++ b/examples/string_difference_test.go
@@ -10,25 +10,25 @@ import (
 func TestStringSimpleMoreTextFails(t *testing.T) {
 	moreTestThan := `Hello, World
 Hello Universe`
-	c := comparabletypes.StringComparable(moreTestThan)
-	expect.FromSnapshot(t, "comparable has more text than snapshot", &c)
+	c := comparabletypes.NewStringComparable(moreTestThan)
+	expect.FromSnapshot(t, "comparable has more text than snapshot", c)
 }
 
 func TestStringSimpleLessTextFails(t *testing.T) {
 	moreTestThan := `Hello World`
-	c := comparabletypes.StringComparable(moreTestThan)
-	expect.FromSnapshot(t, "comparable has less text than snapshot", &c)
+	c := comparabletypes.NewStringComparable(moreTestThan)
+	expect.FromSnapshot(t, "comparable has less text than snapshot", c)
 }
 
 func TestPrettyStringSimpleMoreTextFails(t *testing.T) {
 	moreTestThan := `Hello, World
 Hello Universe`
-	c := comparabletypes.PrettyStringComparable{StringComparable: comparabletypes.StringComparable(moreTestThan)}
-	expect.FromSnapshot(t, "pretty comparable has more text than snapshot", &c)
+	c := comparabletypes.NewPrettyStringComparable(moreTestThan)
+	expect.FromSnapshot(t, "pretty comparable has more text than snapshot", c)
 }
 
 func TestPrettyStringSimpleLessTextFails(t *testing.T) {
 	moreTestThan := `Hello World`
-	c := comparabletypes.PrettyStringComparable{StringComparable: comparabletypes.StringComparable(moreTestThan)}
-	expect.FromSnapshot(t, "pretty comparable has less text than snapshot", &c)
+	c := comparabletypes.NewPrettyStringComparable(moreTestThan)
+	expect.FromSnapshot(t, "pretty comparable has less text than snapshot", c)
 }

--- a/snapshots/comparabletypes/http.go
+++ b/snapshots/comparabletypes/http.go
@@ -174,6 +174,9 @@ func (r *Response) Dump() []byte {
 const headerSep = "\n\n"
 
 func (r *Response) Load(req []byte) snapshots.Comparable {
+	if len(req) == 0 {
+		return &Response{}
+	}
 	splitLine := strings.Index(string(req), headerSep)
 	if splitLine == -1 {
 		panic(fmt.Errorf("cannot read a request in this file"))

--- a/snapshots/comparabletypes/json.go
+++ b/snapshots/comparabletypes/json.go
@@ -21,6 +21,11 @@ func NewJSONFromString(s string) snapshots.Comparable {
 	return &j
 }
 
+func NewJSONFromByes(b []byte) snapshots.Comparable {
+	j := JSON{rawJSON: b}
+	return &j
+}
+
 func (j *JSON) CompareTo(c snapshots.Comparable) (string, error) {
 	opts := jsondiff.DefaultConsoleOptions()
 


### PR DESCRIPTION
Add option to provide a config when loading from snapshot (in cases where you want to do different replacements for a given test)

Update some broken tests

Avoid panicking when loading a response.